### PR TITLE
Greek fonts for linux

### DIFF
--- a/main.css
+++ b/main.css
@@ -93,11 +93,11 @@ span.abbrev{
 
 /*For Greek letters*/
 span.gr{
-	font-family: "New Athena Unicode", "Times New Roman", "Gentium", serif;
+	font-family: "New Athena Unicode", "Times New Roman", "Gentium", "Liberation Serif", serif;
 }
 
 span.lemma{
-	font-family: "New Athena Unicode", "Times New Roman", "Gentium", serif;
+	font-family: "New Athena Unicode", "Times New Roman", "Gentium", "Liberation Serif", serif;
 	font-weight: bold;
 }
 

--- a/main.css
+++ b/main.css
@@ -93,11 +93,11 @@ span.abbrev{
 
 /*For Greek letters*/
 span.gr{
-	font-family: "New Athena Unicode", "Times New Roman", serif;
+	font-family: "New Athena Unicode", "Times New Roman", "Gentium", serif;
 }
 
 span.lemma{
-	font-family: "New Athena Unicode", "Times New Roman", serif;
+	font-family: "New Athena Unicode", "Times New Roman", "Gentium", serif;
 	font-weight: bold;
 }
 


### PR DESCRIPTION
Greek parts in polytonic orthography may not be rendered properly in some Linux environments because Linux distributions do not usually have “Times New Roman”.

Those who use IPA or other extended Latin characters often use “Gentium”.
“Liberation Serif” are supposed to be installed on Ubuntu by default.